### PR TITLE
Add saleor schema before migrations

### DIFF
--- a/saleor/domain_utils.py
+++ b/saleor/domain_utils.py
@@ -89,3 +89,10 @@ def transaction_domain_atomic(fn):
             return fn(*args, **kwargs)
 
     return wrapper
+
+def add_saleor_schema(domain):
+    with connections[domain].cursor() as cursor:
+        try:
+            cursor.execute('CREATE SCHEMA saleor')
+        finally:
+            cursor.close()

--- a/saleor/migrate/tasks.py
+++ b/saleor/migrate/tasks.py
@@ -12,6 +12,7 @@ from ..account.models import Address, User
 from ..celeryconf import app
 from ..domain_task import DomainTask
 from ..domain_utils import (
+    add_saleor_schema,
     update_ecommerce_id,
     update_migration_state,
     setup_celery_connection
@@ -106,4 +107,5 @@ def run_migrations(**kwargs):
     domain = kwargs.get('domain')
 
     setup_celery_connection(domain)
+    add_saleor_schema(domain)
     call_command("migrate", database=domain)


### PR DESCRIPTION
This PR adds `add_saleor_schema` util function to insert `saleor` schema in the database before running django migrations.