### PR TITLE
Fix response treatment and migrate task

### DIFF
--- a/saleor/domain_utils.py
+++ b/saleor/domain_utils.py
@@ -58,8 +58,10 @@ def fetch_credentials(domain=None):
         req = request.Request(url, data=None)
 
         with request.urlopen(req) as response:
-            credentials = response.read().decode('utf-8')
-            return json.loads(credentials)
+            res = response.read().decode('utf-8')
+            credentials = json.loads(res)
+
+            return credentials.get('data')
     except Exception as e:
         raise e
 


### PR DESCRIPTION
This PR fixes how the credentials were being treated after fetching through the `saas-manager` (eg. `credentials.get('data')` after endpoint request). It also improves the signal being used on the `run_migrations` task.