### PR TITLE
Add db schema dynamically

### DIFF
--- a/saleor/core/db/router.py
+++ b/saleor/core/db/router.py
@@ -35,7 +35,6 @@ class DatabaseRouter:
 
         if db_conn is not None and domain is not None:
             connections.databases[domain] = dj_database_url.parse(db_conn)
-            connections.databases[domain]["OPTIONS"] = { "options": "-c search_path=saleor" }
 
         return domain
 

--- a/saleor/core/db/schema.py
+++ b/saleor/core/db/schema.py
@@ -1,0 +1,6 @@
+def set_search_path(sender, **kwargs):
+    conn = kwargs.get('connection')
+
+    if conn is not None:
+        cursor = conn.cursor()
+        cursor.execute("SET search_path=saleor")

--- a/saleor/domain_utils.py
+++ b/saleor/domain_utils.py
@@ -78,7 +78,6 @@ def setup_celery_connection(domain):
     credentials = fetch_credentials(domain)
     connection_string = serialize_connection(credentials)
     connections.databases[domain] = dj_database_url.parse(connection_string)
-    connections.databases[domain]["OPTIONS"] = { "options": '-c search_path=saleor' }
     settings.DOMAIN["celery"] = domain
 
 def transaction_domain_atomic(fn):

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -6,10 +6,11 @@ import dj_email_url
 import sentry_sdk
 from django.contrib.messages import constants as messages
 from django.core.exceptions import ImproperlyConfigured
+from django.db.backends.signals import connection_created
 from django_prices.utils.formatting import get_currency_fraction
 from sentry_sdk.integrations.django import DjangoIntegration
 
-from .domain_utils import fetch_credentials
+from .core.db.schema import set_search_path
 
 def get_list(text):
     return [item.strip() for item in text.split(",")]
@@ -556,3 +557,5 @@ if (
 
 DOMAIN = {}
 DATABASE_ROUTERS = ["saleor.core.db.router.DatabaseRouter"]
+
+connection_created.connect(set_search_path)


### PR DESCRIPTION
This PR adds a db signal handler to django, in order to remove the `OPTIONS` from the db engine and attach the db schema `saleor` dynamically upon each connection created.