### PR TITLE
Add dynamic currency functionality

### DIFF
--- a/saleor/core/middleware.py
+++ b/saleor/core/middleware.py
@@ -12,6 +12,7 @@ from django.utils.functional import SimpleLazyObject
 from django.utils.translation import get_language
 from django_countries.fields import Country
 
+from ..domain_utils import fetch_currency
 from ..discount.utils import fetch_discounts
 from ..extensions.manager import get_extensions_manager
 from ..graphql.views import API_PATH, GraphQLView
@@ -75,7 +76,7 @@ def currency(get_response):
         if hasattr(request, "country") and request.country is not None:
             request.currency = get_currency_for_country(request.country)
         else:
-            request.currency = settings.DEFAULT_CURRENCY
+            request.currency = fetch_currency()
         return get_response(request)
 
     return _currency_middleware

--- a/saleor/core/taxes.py
+++ b/saleor/core/taxes.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.contrib.sites.models import Site
 from prices import Money, MoneyRange, TaxedMoney, TaxedMoneyRange
 
+from ..domain_utils import fetch_currency
 
 class TaxError(Exception):
     """Default tax error."""
@@ -17,10 +18,12 @@ def zero_money(currency: str = settings.DEFAULT_CURRENCY) -> Money:
 
     This is a function used as a model's default.
     """
+    currency = fetch_currency()
     return Money(0, currency)
 
 
 def zero_taxed_money(currency: str = settings.DEFAULT_CURRENCY) -> TaxedMoney:
+    currency = fetch_currency()
     zero = zero_money(currency)
     return TaxedMoney(net=zero, gross=zero)
 

--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -16,6 +16,8 @@ from geolite2 import geolite2
 from prices import MoneyRange
 from versatileimagefield.image_warmer import VersatileImageFieldWarmer
 
+from ...domain_utils import fetch_currency
+
 georeader = geolite2.reader()
 logger = logging.getLogger(__name__)
 
@@ -81,7 +83,7 @@ def get_currency_for_country(country):
     currencies = get_territory_currencies(country.code)
     if currencies:
         return currencies[0]
-    return settings.DEFAULT_CURRENCY
+    return fetch_currency()
 
 
 def to_local_currency(price, currency):

--- a/saleor/discount/models.py
+++ b/saleor/discount/models.py
@@ -10,6 +10,7 @@ from django_prices.models import MoneyField
 from django_prices.templatetags.prices import amount
 from prices import Money, fixed_discount, percentage_discount
 
+from ..domain_utils import fetch_currency
 from ..core.permissions import DiscountPermissions
 from ..core.utils.translations import TranslationProxy
 from . import DiscountValueType, VoucherType
@@ -115,7 +116,7 @@ class Voucher(models.Model):
 
     def get_discount(self):
         if self.discount_value_type == DiscountValueType.FIXED:
-            discount_amount = Money(self.discount_value, settings.DEFAULT_CURRENCY)
+            discount_amount = Money(self.discount_value, fetch_currency())
             return partial(fixed_discount, discount=discount_amount)
         if self.discount_value_type == DiscountValueType.PERCENTAGE:
             return partial(percentage_discount, percentage=self.discount_value)
@@ -230,7 +231,7 @@ class Sale(models.Model):
 
     def get_discount(self):
         if self.type == DiscountValueType.FIXED:
-            discount_amount = Money(self.value, settings.DEFAULT_CURRENCY)
+            discount_amount = Money(self.value, fetch_currency())
             return partial(fixed_discount, discount=discount_amount)
         if self.type == DiscountValueType.PERCENTAGE:
             return partial(percentage_discount, percentage=self.value)

--- a/saleor/domain_task.py
+++ b/saleor/domain_task.py
@@ -1,5 +1,5 @@
 from celery import Task
-from .domain_utils import get_domain
+from .domain_utils import get_domain, fetch_currency
 
 class DomainTask(Task):
     abstract = True
@@ -17,4 +17,7 @@ class DomainTask(Task):
         return super(DomainTask, self).retry(args, kwargs, **rest)
 
     def _include_request_context(self, kwargs):
-        kwargs["domain"] = get_domain()
+        domain = get_domain()
+        currency = fetch_currency(domain)
+        kwargs["domain"] = domain
+        kwargs["currency"] = currency

--- a/saleor/extensions/plugins/webhook/__init__.py
+++ b/saleor/extensions/plugins/webhook/__init__.py
@@ -19,7 +19,11 @@ def create_webhook_headers(
 ):
     signature_prefix = "sha1="
     domain = Site.objects.get_current().domain
-    headers = {"X-Saleor-Event": event_name, "X-Saleor-Domain": domain}
+    headers = {
+        "Content-Type": 'application/json',
+        "X-Saleor-Event": event_name,
+        "X-Saleor-Domain": domain
+    }
     if secret_key and body:
         saleor_hmac_sha256 = signature_prefix + create_hmac_signature(
             body, secret_key, encoding

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -29,7 +29,7 @@ from ...core.permissions import OrderPermissions
 from ...core.taxes import TaxError
 from ...core.utils.url import validate_storefront_url
 from ...discount import models as voucher_model
-from ...domain_utils import transaction_domain_atomic
+from ...domain_utils import transaction_domain_atomic, fetch_currency
 from ...payment import PaymentError, gateway, models as payment_models
 from ...payment.interface import AddressData
 from ...payment.utils import store_customer_id
@@ -217,6 +217,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
 
     @classmethod
     def clean_input(cls, info, instance: models.Checkout, data, input_cls=None):
+        instance.currency = fetch_currency()
         cleaned_input = super().clean_input(info, instance, data)
         user = info.context.user
         country = info.context.country.code

--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -2,6 +2,7 @@ import graphene
 from django.core.exceptions import ValidationError
 from graphene.types import InputObjectType
 
+from ....domain_utils import fetch_currency
 from ....account.models import User
 from ....core.exceptions import InsufficientStock
 from ....core.permissions import OrderPermissions
@@ -84,6 +85,7 @@ class DraftOrderCreate(ModelMutation, I18nMixin):
 
     @classmethod
     def clean_input(cls, info, instance, data):
+        instance.currency = fetch_currency()
         shipping_address = data.pop("shipping_address", None)
         billing_address = data.pop("billing_address", None)
         cleaned_input = super().clean_input(info, instance, data)

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -2,6 +2,7 @@ import graphene
 from django.conf import settings
 from django.core.exceptions import ValidationError
 
+from ...domain_utils import fetch_currency
 from ...core.permissions import OrderPermissions
 from ...core.taxes import zero_taxed_money
 from ...core.utils import get_client_ip
@@ -124,7 +125,7 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
             gateway=data["gateway"],
             payment_token=data["token"],
             total=amount,
-            currency=settings.DEFAULT_CURRENCY,
+            currency=fetch_currency(),
             email=checkout.email,
             extra_data=extra_data,
             customer_ip_address=get_client_ip(info.context),

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -60,7 +60,7 @@ from ..utils import (
     validate_attribute_input_for_variant,
 )
 
-from ....domain_utils import transaction_domain_atomic
+from ....domain_utils import transaction_domain_atomic, fetch_currency
 
 class CategoryInput(graphene.InputObjectType):
     description = graphene.String(description="Category description (HTML/text).")
@@ -796,6 +796,7 @@ class ProductCreate(ModelMutation):
         # `Product` model, which is HStore field that maps attribute's PK to
         # the value's PK.
 
+        instance.currency = fetch_currency()
         attributes = cleaned_input.get("attributes")
         product_type = (
             instance.product_type if instance.pk else cleaned_input.get("product_type")
@@ -908,7 +909,7 @@ class ProductCreate(ModelMutation):
             )
             sku = cleaned_input.get("sku")
             variant = models.ProductVariant.objects.create(
-                product=instance, track_inventory=track_inventory, sku=sku
+                product=instance, track_inventory=track_inventory, sku=sku, currency=instance.currency
             )
             quantity = cleaned_input.get("quantity")
             if quantity is not None:
@@ -1116,6 +1117,7 @@ class ProductVariantCreate(ModelMutation):
     def clean_input(
         cls, info, instance: models.ProductVariant, data: dict, input_cls=None
     ):
+        instance.currency = fetch_currency()
         cleaned_input = super().clean_input(info, instance, data)
 
         if "cost_price" in cleaned_input:

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -5,6 +5,7 @@ from django_countries import countries
 from django_prices_vatlayer.models import VAT
 from phonenumbers import COUNTRY_CODE_TO_REGION_CODE
 
+from ...domain_utils import fetch_currency
 from ...account import models as account_models
 from ...core.permissions import SitePermissions, get_permissions
 from ...core.utils import get_client_ip, get_country_by_ip
@@ -199,7 +200,7 @@ class Shop(graphene.ObjectType):
 
     @staticmethod
     def resolve_default_currency(_, _info):
-        return settings.DEFAULT_CURRENCY
+        return fetch_currency()
 
     @staticmethod
     def resolve_description(_, info):

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -8,7 +8,7 @@ from ..core.taxes import zero_money
 from ..core.weight import zero_weight
 from ..discount.models import NotApplicable, Voucher, VoucherType
 from ..discount.utils import get_products_voucher_discount, validate_voucher_in_order
-from ..domain_utils import transaction_domain_atomic
+from ..domain_utils import transaction_domain_atomic, fetch_currency
 from ..extensions.manager import get_extensions_manager
 from ..order import OrderStatus
 from ..order.models import Order, OrderLine
@@ -296,7 +296,7 @@ def restock_fulfillment_lines(fulfillment):
 
 
 def sum_order_totals(qs):
-    zero = Money(0, currency=settings.DEFAULT_CURRENCY)
+    zero = Money(0, currency=fetch_currency())
     taxed_zero = TaxedMoney(zero, zero)
     return sum([order.total for order in qs], taxed_zero)
 

--- a/saleor/payment/models.py
+++ b/saleor/payment/models.py
@@ -13,6 +13,7 @@ from ..core.taxes import zero_money
 from ..order.models import Order
 from . import ChargeStatus, CustomPaymentChoices, TransactionError, TransactionKind
 
+from ..domain_utils import fetch_currency
 
 class Payment(models.Model):
     """A model that represents a single payment.
@@ -99,7 +100,7 @@ class Payment(models.Model):
         return max(self.transactions.all(), default=None, key=attrgetter("pk"))
 
     def get_total(self):
-        return Money(self.total, self.currency or settings.DEFAULT_CURRENCY)
+        return Money(self.total, fetch_currency())
 
     def get_authorized_amount(self):
         money = zero_money()
@@ -127,14 +128,14 @@ class Payment(models.Model):
 
         # Calculate authorized amount from all succeeded auth transactions
         for txn in authorized_txns:
-            money += Money(txn.amount, self.currency or settings.DEFAULT_CURRENCY)
+            money += Money(txn.amount, fetch_currency())
 
         # If multiple partial capture is supported later though it's unlikely,
         # the authorized amount should exclude the already captured amount here
         return money
 
     def get_captured_amount(self):
-        return Money(self.captured_amount, self.currency or settings.DEFAULT_CURRENCY)
+        return Money(self.captured_amount,fetch_currency())
 
     def get_charge_amount(self):
         """Retrieve the maximum capture possible."""
@@ -220,4 +221,4 @@ class Transaction(models.Model):
         )
 
     def get_amount(self):
-        return Money(self.amount, self.currency or settings.DEFAULT_CURRENCY)
+        return Money(self.amount, fetch_currency())


### PR DESCRIPTION
This PR introduces a different way to handle the currency in Saleor. We can't remove `DEFAULT_CURRENCY` because of how its used statically (eg. database models) but we can "intercept" the graphql calls that will need a currency somehow and inject the current domain default currency, allowing us to have dynamic currency based on the domain.